### PR TITLE
chore: change old contact link to the Slack one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ git config core.hookspath .githooks
 
 ## Contact
 
-Feel free to drop by in our Matrix chat room: https://matrix.to/#/#testcontainers-rs:matrix.org
+Feel free to drop by in our Slack: http://slack.testcontainers.org/


### PR DESCRIPTION
Inside of the Matrix channel, it is mentioned that the official contact channel is now Slack.